### PR TITLE
save MQTT protocol version for packet; implement StateGet method; sav…

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -9,13 +9,14 @@ import (
 )
 
 var (
-	bucketRetained      = []byte("retained")
-	bucketSessions      = []byte("sessions")
-	bucketSubscriptions = []byte("subscriptions")
-	bucketExpire        = []byte("expire")
-	bucketPackets       = []byte("packets")
-	bucketState         = []byte("state")
-	bucketSystem        = []byte("system")
+	bucketRetained      						  = []byte("retained")
+	bucketSessions     							  = []byte("sessions")
+	bucketSubscriptions 						  = []byte("subscriptions")
+	bucketExpire        						  = []byte("expire")
+	bucketPackets       						  = []byte("packets")
+	bucketState         						  = []byte("state")
+	bucketSystem        						  = []byte("system")
+	bucketLastCompletedSubscribedMessageUniqueIds = []byte("lcsmuids")
 )
 
 // Config configuration of the BoltDB backend

--- a/retained.go
+++ b/retained.go
@@ -3,7 +3,6 @@ package boltdb
 import (
 	"sync"
 	"github.com/VolantMQ/persistence"
-	"github.com/VolantMQ/volantmq/packet"
 	"github.com/boltdb/bolt"
 )
 
@@ -28,7 +27,7 @@ func (r *retained) Load() ([]persistence.PersistedPacket, error) {
 				pkt.Data = buck.Get([]byte("data"))
 				pkt.ExpireAt = string(buck.Get([]byte("expireAt")))
 				if pktVersion := buck.Get([]byte("version")); pktVersion != nil {
-					pkt.Version = packet.ProtocolVersion(pktVersion[0])
+					pkt.Version = persistence.ProtocolVersion(pktVersion[0])
 				}
 				res = append(res, pkt)
 			}


### PR DESCRIPTION
save MQTT protocol version for the packet, so when loading packets from the persisted storage, they will be decoded correctly. currently, volantmq reads the version from the first byte which may be wrong.

save last completed subscribed message IDs(nano timestamp, created by the patch for volantmqt when create a new publish packet)  in the session state, when session loaded, they can used to de-dup the retained messages. Acorrdingly, the SateGet method was added. 