### PR TITLE
Packet version and last completed subscribed message IDs should be persisted

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -9,13 +9,14 @@ import (
 )
 
 var (
-	bucketRetained      = []byte("retained")
-	bucketSessions      = []byte("sessions")
-	bucketSubscriptions = []byte("subscriptions")
-	bucketExpire        = []byte("expire")
-	bucketPackets       = []byte("packets")
-	bucketState         = []byte("state")
-	bucketSystem        = []byte("system")
+	bucketRetained      						  = []byte("retained")
+	bucketSessions     							  = []byte("sessions")
+	bucketSubscriptions 						  = []byte("subscriptions")
+	bucketExpire        						  = []byte("expire")
+	bucketPackets       						  = []byte("packets")
+	bucketState         						  = []byte("state")
+	bucketSystem        						  = []byte("system")
+	bucketLastCompletedSubscribedMessageUniqueIds = []byte("lcsmuids")
 )
 
 // Config configuration of the BoltDB backend

--- a/retained.go
+++ b/retained.go
@@ -3,7 +3,6 @@ package boltdb
 import (
 	"sync"
 	"github.com/VolantMQ/persistence"
-	"github.com/VolantMQ/volantmq/packet"
 	"github.com/boltdb/bolt"
 )
 
@@ -28,7 +27,7 @@ func (r *retained) Load() ([]persistence.PersistedPacket, error) {
 				pkt.Data = buck.Get([]byte("data"))
 				pkt.ExpireAt = string(buck.Get([]byte("expireAt")))
 				if pktVersion := buck.Get([]byte("version")); pktVersion != nil {
-					pkt.Version = packet.ProtocolVersion(pktVersion[0])
+					pkt.Version = persistence.ProtocolVersion(pktVersion[0])
 				}
 				res = append(res, pkt)
 			}

--- a/sessions.go
+++ b/sessions.go
@@ -233,12 +233,6 @@ func (s *sessions) StateStore(id []byte, state *persistence.SessionState) error 
 			return err
 		}
 
-		if len(state.Subscriptions) > 0 {
-			if err = st.Put(bucketSubscriptions, state.Subscriptions); err != nil {
-				return err
-			}
-		}
-
 		if err = st.Put([]byte("timestamp"), []byte(state.Timestamp)); err != nil {
 			return err
 		}
@@ -357,7 +351,7 @@ func ParseState(sessionBucket *bolt.Bucket)(st *persistence.SessionState){
 		}
 
 		st.Timestamp = string(state.Get([]byte("timestamp")))
-		st.Subscriptions = state.Get(bucketSubscriptions)
+		st.Subscriptions = sessionBucket.Get(bucketSubscriptions)
 
 		if expire := state.Bucket(bucketExpire); expire != nil {
 			st.Expire = &persistence.SessionDelays{


### PR DESCRIPTION
this commit is to be compaliant with persistence-boldtdb for the same issues on https://github.com/VolantMQ/persistence/pull/2